### PR TITLE
Use public URL for bcftools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/xxsds/sdsl-lite
 [submodule "bcftools"]
 	path = bcftools
-	url = git@github.com:samtools/bcftools.git
+	url = https://github.com/samtools/bcftools.git


### PR DESCRIPTION
git clone --recursive https://github.com/alshai/rowbowt was failing for me, ultimately because of the git-style URL used here for the bcftools submodule.  I think this fixes it.