### PR TITLE
Fixing 2 things to allow vcf_to_bwt to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CXX_FLAGS=-std=c++11 -Ofast -Wall -Wextra -march=native -g
 CFLAGS=-O3 -Wall -std=c99 -g
 CC=gcc
 CXX=g++
-INC=-I./include
+INC=-I./include -I.
 SDSL_INC=-I./sdsl-lite/include
 
 # main executables

--- a/src/vcf_scan.cpp
+++ b/src/vcf_scan.cpp
@@ -213,7 +213,7 @@ void scan_vcf_sample(Args args, std::string sample) {
             }
         } else { // end of contig
             if (args.mai) {
-                mi_writer.finish_sequence(static_cast<size_t>(static_cast<int64_t>(ref_len) + bias + args.w));
+                mi_writer.finish_sequence();
                 //fprintf(stderr, "bias: %ld\n", bias);
             }
             update_sequence(ref_seq, ref_len, NULL, ppos_after, -1, fa_fp, log);


### PR DESCRIPTION
This request contains two fixes that allow a `make` in the `pfbwt-f` directory to finish successfully.  Originally, there were errors relating to the gsacak.hpp header and another one related to an incorrect argument being passed to `MarkerPositionsWriter::finish_sequence()` function.